### PR TITLE
Implement named scopes in row_source (Phase 1)

### DIFF
--- a/.claude/plans/row-source.md
+++ b/.claude/plans/row-source.md
@@ -4,19 +4,24 @@ Two related improvements to the YAML extension mechanism. They can be implemente
 sequentially on one branch or separately; Phase 1 is a prerequisite for Phase 2's
 scope-aware path resolution.
 
+Scope references use a consistent `in <name>` suffix, mirroring the `as <name>` suffix
+in `row_source` declarations: `as` binds a name, `in` references it.
+
 ---
 
 ## Phase 1: Named Scopes in `row_source`
+
+**Status: implemented with `<scope>.` prefix syntax — needs revision to `in <scope>` suffix.**
 
 ### Goal
 
 Replace the `^` parent-hop syntax with named scope references.
 
 **Single row_source** (the common case — default `["items"]` or one explicit entry):
-path expressions resolve against the one implicit object; no scope prefix required.
+path expressions resolve against the one implicit object; no scope qualifier required.
 
 **Multiple row_source entries**: every entry must carry `as <name>`, and every path /
-label expression must begin with an explicit scope name.  There is no implicit
+label expression must end with an explicit `in <name>` qualifier.  There is no implicit
 "current object" when more than one level exists.
 
 ```yaml
@@ -28,9 +33,9 @@ create:
       - spec.taints as taint
     columns:
       - name: node_uid
-        path: node.metadata.uid
+        path: metadata.uid in node
       - name: taint_key
-        path: taint.key
+        path: key in taint
 ```
 
 ### Changes
@@ -45,28 +50,26 @@ create:
 
 - Add `_scopes: dict[int, dict[str, object]]`.  Key is `id(child)`; value is the
   map of scope names visible at that child's level.
-- Update `set_parent` to also record named scopes: when a child is created from a
-  level that had a name, include that name → parent-object in the child's scope map,
-  merging with any scopes already inherited.
-- Add `get_scope(child, name) -> Optional[object]` that walks up the scope chain
-  to find the named object.
+- `set_scope(child, name, parent)` records the child's scope map, inheriting all
+  ancestor scopes from parent and adding `name → child`.
+- Add `get_scope(obj, name) -> Optional[object]` that looks up the named object.
 
 **`kugl/impl/tables.py` — `TableFromConfig._itemize`**
 
-- After calling `context.set_parent(child, item)`, also call a new
+- After calling `context.set_parent(child, item)`, also call
   `context.set_scope(child, source.name, item)` when `source.name` is not None,
   carrying forward all ancestor scopes so deeper levels can still reference `node`.
 
 **`kugl/impl/extract.py` — `FieldRef` / `PathExtractor` / `LabelExtractor`**
 
-- `FieldRef.parse`: remove `^` handling; detect a leading `<word>.` prefix as a
+- `FieldRef.parse`: remove `^` handling; detect a trailing ` in <word>` suffix as a
   scope name.  Store as `scope_name: Optional[str]` and strip it from the target
   before JMESPath compilation.
 - In `PathExtractor.extract` and `LabelExtractor.extract`, when `self._ref.scope_name`
   is set, resolve the object via `context.get_scope(obj, scope_name)`.
 - Validation at table-build time (`TableFromConfig.__init__`): if `len(row_source) > 1`,
-  every `row_source` entry must have a name and every column path/label must carry a
-  scope prefix; raise a clear `ConfigError` if either constraint is violated.
+  every `row_source` entry must have a name and every column path/label must carry an
+  `in <name>` qualifier; raise a clear `ConfigError` if either constraint is violated.
 
 ### Builtin Update
 
@@ -79,9 +82,9 @@ as a self-contained example:
       - spec.taints as taint
     columns:
       - name: node_uid
-        path: node.metadata.uid
+        path: metadata.uid in node
       - name: taint_key
-        path: taint.key
+        path: key in taint
 ```
 
 ### Tests
@@ -101,9 +104,10 @@ as a self-contained example:
 ### Goal
 
 Replace the two-key `path:` / `label:` vocabulary with a single `from:` key that
-auto-detects extraction type.  Named scope prefixes compose naturally.
+auto-detects extraction type.  Named scope qualifiers compose naturally via the same
+`in <name>` suffix.
 
-Single row_source (bare paths, no scope prefix needed):
+Single row_source (no scope qualifier needed):
 
 ```yaml
     columns:
@@ -121,24 +125,27 @@ Multi-step row_source (all entries named, all columns scoped):
       - spec.containers as container
     columns:
       - name: pod_name
-        from: pod.metadata.name           # named scope + JMESPath
+        from: metadata.name in pod            # JMESPath on pod scope
       - name: pod_pool
-        from: pod.karpenter.sh/nodepool   # named scope + label
+        from: karpenter.sh/nodepool in pod    # label on pod scope — unambiguous
       - name: container_name
-        from: container.name              # named scope + JMESPath
+        from: name in container               # JMESPath on container scope
 ```
 
 ### Auto-Detection Rule
 
-After stripping any `<scope>.` prefix:
+Strip any trailing ` in <word>` suffix first, then apply to the remainder:
 
 - Matches `[a-zA-Z0-9.-]+/[a-zA-Z0-9._/-]+` (K8s label format: DNS domain + `/` +
   key) → `LabelExtractor`
 - Otherwise → `PathExtractor`
 
 A value like `metadata.labels.foo/bar` is a JMESPath, not a label — the `/` appears
-inside a path segment, not as the label-domain separator.  The regex above handles
-this correctly because `metadata.labels.foo` is not a valid DNS domain segment.
+inside a path segment, not as the label-domain separator.  The regex handles this
+correctly because `metadata.labels.foo` is not a valid DNS domain segment.
+
+Parsing ` in <word>` is safe because neither JMESPath expressions nor label keys
+contain spaces, so the delimiter is unambiguous.
 
 ### Changes
 
@@ -148,34 +155,30 @@ this correctly because `metadata.labels.foo` is not a valid DNS domain segment.
   because `from` is a Python keyword).
 - In `gen_extractor`, handle `from_` alongside `path` and `label`.
   - If `from_` is set alongside `path` or `label`, raise `ValueError`.
-  - Parse any scope prefix from `from_`.
+  - Strip any ` in <word>` suffix from `from_` to extract the scope name.
   - Apply the label-vs-path regex to the remainder.
   - Construct the appropriate extractor, passing the scope name through.
 - Keep `path:` and `label:` fully supported so existing configs are not broken.
 
 **`kugl/impl/extract.py` — `FieldRef`**
 
-- Move the scope-prefix parsing here; `gen_extractor`
-  delegates to `FieldRef.parse_from(s, known_scopes=None)`.
-- Known scopes are not available at Pydantic parse time (they live in `CreateTable`
-  which is a sibling, not a parent).  Two options:
-  - **Lazy validation**: accept any `<word>.` prefix as a potential scope; fail at
-    table-build time in `TableFromConfig.__init__` if a referenced scope name is not
-    declared in `row_source`.
-  - **Two-pass**: `CreateTable` validates column scope references after parsing.
-  Lazy validation is simpler and consistent with how `path:` expressions are
-  currently validated (JMESPath compilation errors surface at parse time, but
-  missing-path errors surface at query time).
+- Centralise the ` in <scope>` parsing in `FieldRef.parse_scoped(s)`; both
+  `gen_extractor` (for `from:`) and `FieldRef.parse` (for `path:`/`label:`) delegate
+  to it.
+- Known scopes are not available at Pydantic parse time.  Use lazy validation: accept
+  any ` in <word>` suffix as a potential scope; fail at table-build time in
+  `TableFromConfig.__init__` if the referenced scope name is not declared in
+  `row_source`.
 
 ### Tests
 
 - `from: karpenter.sh/nodepool` produces the same result as `label: karpenter.sh/nodepool`.
 - `from: spec.providerID` produces the same result as `path: spec.providerID`.
-- `from: node.metadata.name` with a named `node` scope resolves correctly.
-- `from: node.karpenter.sh/nodepool` with a named `node` scope resolves as a label
-  on the node object.
+- `from: metadata.name in pod` with a named `pod` scope resolves correctly.
+- `from: karpenter.sh/nodepool in pod` with a named `pod` scope resolves as a label
+  on the pod object.
 - Error: `from:` and `path:` both specified → validation error.
-- Error: `from: unknownscope.foo` where `unknownscope` is not in `row_source` → clear
+- Error: `from: foo in unknownscope` where `unknownscope` is not in `row_source` → clear
   error message at table-build time.
 
 ---
@@ -184,7 +187,7 @@ this correctly because `metadata.labels.foo` is not a valid DNS domain segment.
 
 | File | Change |
 |---|---|
-| `kugl/impl/extract.py` | `FieldRef.parse`: detect scope prefix; extractors: resolve via scope |
+| `kugl/impl/extract.py` | `FieldRef.parse`: detect ` in <scope>` suffix; extractors: resolve via scope |
 | `kugl/impl/tables.py` | `Itemizer`: parse `as <name>`; `RowContext`: track named scopes |
 | `kugl/impl/config.py` | `UserColumn`: add `from_` field and dispatch in `gen_extractor` |
 | `kugl/builtins/schemas/kubernetes.yaml` | Convert `node_taints` to named scope syntax |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.9.0
+
+- Named scope syntax for multi-step ``row_source``: each entry takes ``as <name>`` and
+  columns reference ancestor objects with ``in <name>`` suffix (e.g. ``metadata.uid in node``);
+  the old ``^`` parent-hop syntax is removed
+- New ``from:`` column key that auto-detects label vs JMESPath: values matching
+  ``domain/key`` format (e.g. ``karpenter.sh/nodepool``) use label extraction, everything
+  else uses JMESPath
+
 ## 0.8.0
 
 New tables in ``kubernetes`` schema:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,12 @@ CLI changes (breaking):
 
 Extending tables:
 
-- Named scope syntax for multi-step ``row_source``: each entry takes ``as <name>`` and
+- Breaking: Named scope syntax for multi-step ``row_source``: each entry takes ``as <name>`` and
   columns reference ancestor objects with ``in <name>`` suffix (e.g. ``metadata.uid in node``);
   the old ``^`` parent-hop syntax is removed
 - New ``from:`` column key that auto-detects label vs JMESPath: values matching
   ``domain/key`` format (e.g. ``karpenter.sh/nodepool``) use label extraction, everything
-  else uses JMESPath
+  else uses JMESPath (``path:`` and ``label:`` to be removed in a future release)
 
 Documentation:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,3 @@
-## 0.9.0
-
-- Named scope syntax for multi-step ``row_source``: each entry takes ``as <name>`` and
-  columns reference ancestor objects with ``in <name>`` suffix (e.g. ``metadata.uid in node``);
-  the old ``^`` parent-hop syntax is removed
-- New ``from:`` column key that auto-detects label vs JMESPath: values matching
-  ``domain/key`` format (e.g. ``karpenter.sh/nodepool``) use label extraction, everything
-  else uses JMESPath
-
 ## 0.8.0
 
 New tables in ``kubernetes`` schema:
@@ -16,7 +7,7 @@ New tables in ``kubernetes`` schema:
 - ``services`` and ``service_labels``
 - ``deployments`` and ``deployment_labels``
 
-CLI changes:
+CLI changes (breaking):
 
 - Added ``-c``/``--context`` option to specify a Kubernetes context
 - Renamed ``-a`` option to ``-A`` for consistency with ``kubectl``
@@ -24,9 +15,19 @@ CLI changes:
 - Renamed ``-u``/``--update`` to ``-r``/``--refresh``
 - Renamed ``-r``/``--reckless`` to ``-q``/``--quiet`` (and ``reckless:`` in settings to ``quiet:``)
 
-Other:
+Extending tables:
+
+- Named scope syntax for multi-step ``row_source``: each entry takes ``as <name>`` and
+  columns reference ancestor objects with ``in <name>`` suffix (e.g. ``metadata.uid in node``);
+  the old ``^`` parent-hop syntax is removed
+- New ``from:`` column key that auto-detects label vs JMESPath: values matching
+  ``domain/key`` format (e.g. ``karpenter.sh/nodepool``) use label extraction, everything
+  else uses JMESPath
+
+Documentation:
 
 - New masthead example of ``kugl`` vs ``kubectl | jq``
+
 
 ## 0.7.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,13 +140,14 @@ extend:
 
 ## Column Extractors
 
-Two extractor types, specified by keyword in a column definition:
+Three extractor keys, specified in a column definition:
 
 **`path:`** — JMESPath expression into the current row item  
-**`label:`** — shortcut to `metadata.labels`; can be a list to try in order
+**`label:`** — shortcut to `metadata.labels`; can be a list to try in order  
+**`from:`** — unified key that auto-detects label vs path: values matching `domain/key` (e.g. `karpenter.sh/nodepool`) use `LabelExtractor`; everything else uses `PathExtractor`
 
-**Named scope navigation** — in multi-step `row_source`, each entry must carry `as <name>`, and every column path/label must be prefixed with a scope name:
-- `node.metadata.uid` extracts `metadata.uid` from the object named `node` at a higher level
+**Named scope navigation** — in multi-step `row_source`, each entry must carry `as <name>`, and every column expression must end with `in <name>` to identify which scope to resolve against:
+- `metadata.uid in node` extracts `metadata.uid` from the object named `node` at a higher level
 - All named scopes from ancestor levels are available at each step
 
 ## Column Types
@@ -175,14 +176,14 @@ row_source:
   - spec.taints as taint  # step 2: each taint within each node, named "taint"
 columns:
   - name: node_uid
-    path: node.metadata.uid   # scope prefix "node." resolves to the step-1 object
+    path: metadata.uid in node   # "in node" suffix resolves to the step-1 object
   - name: taint_key
-    path: taint.key           # scope prefix "taint." resolves to the step-2 object
+    path: key in taint           # "in taint" suffix resolves to the step-2 object
 ```
 
 - Each step applies to results of the prior step
-- Multi-step tables require `as <name>` on every entry; all column paths/labels must carry a scope prefix
-- Single-step tables use bare JMESPath paths with no scope prefix
+- Multi-step tables require `as <name>` on every entry; all column paths/labels must end with `in <name>`
+- Single-step tables use bare JMESPath paths with no scope qualifier
 - Dict sources can be unpacked to key/value pairs with `; kv` suffix: `- env; kv`
 - Default `row_source` is `["items"]`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,9 +145,9 @@ Two extractor types, specified by keyword in a column definition:
 **`path:`** — JMESPath expression into the current row item  
 **`label:`** — shortcut to `metadata.labels`; can be a list to try in order
 
-**Parent navigation** — prefix `^` chars to walk up the `row_source` chain:
-- `^metadata.uid` means `.metadata.uid` one level above the current item
-- `^^foo` means two levels up
+**Named scope navigation** — in multi-step `row_source`, each entry must carry `as <name>`, and every column path/label must be prefixed with a scope name:
+- `node.metadata.uid` extracts `metadata.uid` from the object named `node` at a higher level
+- All named scopes from ancestor levels are available at each step
 
 ## Column Types
 
@@ -171,12 +171,18 @@ Multi-step JMESPath iteration for generating multiple rows per API response item
 
 ```yaml
 row_source:
-  - items          # step 1: each element of the top-level items array
-  - spec.taints    # step 2: each taint within each node
+  - items as node       # step 1: each element of the top-level items array, named "node"
+  - spec.taints as taint  # step 2: each taint within each node, named "taint"
+columns:
+  - name: node_uid
+    path: node.metadata.uid   # scope prefix "node." resolves to the step-1 object
+  - name: taint_key
+    path: taint.key           # scope prefix "taint." resolves to the step-2 object
 ```
 
 - Each step applies to results of the prior step
-- Parent/child relationships are tracked for `^` path navigation
+- Multi-step tables require `as <name>` on every entry; all column paths/labels must carry a scope prefix
+- Single-step tables use bare JMESPath paths with no scope prefix
 - Dict sources can be unpacked to key/value pairs with `; kv` suffix: `- env; kv`
 - Default `row_source` is `["items"]`
 

--- a/docs/breaking.rst
+++ b/docs/breaking.rst
@@ -9,8 +9,16 @@ Please expect bugs and backward-incompatible changes.
 0.8.0
 ~~~~~
 
+Breaking changes are significant, gearing up for a 1.0 release.
+
 The new `from:` syntax alternative to `path:` and `label:` is backwards compatible, but
 the old syntax is deprecated and will be removed in a future release.
+
+Extending tables:
+
+- Named scope syntax for multi-step ``row_source``: each entry takes ``as <name>`` and
+  columns reference ancestor objects with ``in <name>`` suffix (e.g. ``metadata.uid in node``);
+  the old ``^`` parent-hop syntax is removed
 
 CLI changes:
 

--- a/docs/breaking.rst
+++ b/docs/breaking.rst
@@ -9,6 +9,9 @@ Please expect bugs and backward-incompatible changes.
 0.8.0
 ~~~~~
 
+The new `from:` syntax alternative to `path:` and `label:` is backwards compatible, but
+the old syntax is deprecated and will be removed in a future release.
+
 CLI changes:
 
 - Added ``-c``/``--context`` option to specify a Kubernetes context

--- a/docs/extending.rst
+++ b/docs/extending.rst
@@ -85,7 +85,19 @@ Column extractors and defaults
 You've seen how the ``path`` extractor works, using JMESPath to identify
 an element in the response JSON. You can also use the ``label``
 extractor, which is a shortcut to ``metadata.labels``, and can either be
-a single string or a list of labels to check in order
+a single string or a list of labels to check in order.
+
+A third option, ``from:``, combines both: Kugl auto-detects whether a
+value is a label (matches ``domain/key`` format like
+``karpenter.sh/nodepool``) or a JMESPath expression (everything else).
+So these two column definitions are equivalent:
+
+.. code:: yaml
+
+   - name: node_pool
+     label: karpenter.sh/nodepool
+   - name: node_pool
+     from: karpenter.sh/nodepool
 
 There are some useful defaults as well:
 
@@ -152,30 +164,29 @@ a pod can have multiple containers. Kugl handles this using the
      - table: node_taints
        resource: nodes
        row_source:
-         - items
-         - spec.taints
+         - items as node
+         - spec.taints as taint
        columns:
          - name: node_uid
-           path: ^metadata.uid
+           path: metadata.uid in node
          - name: key
-           path: key
+           path: key in taint
          - name: effect
-           path: effect
+           path: effect in taint
 
-Each element in ``row_source`` is a JMESPath expression that selects
-items relative to the prior selector. Only the last element in the list
-is used to generate a row, but ``path``\ s can refer to any part of the
-chain. Each ``"^"`` at the start of a ``path`` refers to the part of the
-response one level higher than the bottom ``row_source`` element. In
-this case
+Each element in ``row_source`` is a JMESPath expression followed by an
+``as <name>`` label. Every step must be named when the table has more
+than one ``row_source`` entry. Column ``path`` and ``label`` values
+identify which level they address by ending with ``in <name>``:
 
-- ``^metadata.uid`` means the ``.metadata.uid`` in each element of the
-  response ``items`` array
-- ``key`` and ``effect`` refer to each taint in the ``spec.taints``
-  array
+- ``metadata.uid in node`` reads ``.metadata.uid`` from each element of
+  the ``items`` array (named ``node``)
+- ``key in taint`` and ``effect in taint`` read fields from each taint
+  in the ``spec.taints`` array (named ``taint``)
 
 The default ``row_source`` is just ``items``, which is why the example
-``workflows`` table shown earlier doesn't need to specify it.
+``workflows`` table shown earlier doesn't need to specify it. Single-step
+tables use bare JMESPath paths with no ``in <name>`` qualifier.
 
 This syntax also applies to the ``label`` extractor. For example, if the
 ``row_source`` of a table needs to address Job metadata but also
@@ -186,13 +197,13 @@ metadata from the Job pod template, you can write this:
      ...
      resource: jobs
      row_source:
-       - items
-       - spec.template
+       - items as job
+       - spec.template as template
      columns:
        - name: label_from_job
-         label: ^a-job-label
+         label: a-job-label in job
        - name: label_from_pod
-         label: a-pod-label
+         label: a-pod-label in template
 
 More about row_source
 ~~~~~~~~~~~~~~~~~~~~~
@@ -213,8 +224,8 @@ In detail, here's how ``row_source`` is handled.
 - Repeat with each successive ``row_source`` entry.
 
 This can produce surprising results if one step in the ``row_source``
-list tries to do too much. Let's say the ``node_taints`` table didn't
-need a ``^metadata.uid`` reference, so only requires the taint lists.
+list tries to do too much. Let's say the ``node_taints`` table only
+needed the taint lists, with no reference to node metadata.
 This source list would not work, because ``.spec`` is not a child of
 ``.items``.
 

--- a/docs/multi.rst
+++ b/docs/multi.rst
@@ -28,19 +28,19 @@ query. For example: if ``~/.kugl/ec2.yaml`` contains
      - table: instances
        resource: instances
        row_source:
-         - Reservations
-         - Instances
+         - Reservations as reservation
+         - Instances as instance
        columns:
          - name: type
-           path: InstanceType
+           path: InstanceType in instance
          - name: zone
-           path: Placement.AvailabilityZone
+           path: Placement.AvailabilityZone in instance
          - name: private_dns
-           path: PrivateDnsName
+           path: PrivateDnsName in instance
          - name: state
-           path: State.Name
+           path: State.Name in instance
          - name: launched
-           path: LaunchTime
+           path: LaunchTime in instance
 
 you can write
 

--- a/docs/resources.rst
+++ b/docs/resources.rst
@@ -124,14 +124,12 @@ To build a table showing environment settings by region:
      - table: env_settings
        resource: by_region
        row_source:
-         # Address each element in the result list
-         - "[]"
-         # Focus on the environment settings
-         - content.env
+         - "[]" as file
+         - content.env as setting
        columns:
          - name: region
-           path: ^match.region
+           path: match.region in file
          - name: name
-           path: name
+           path: name in setting
          - name: value
-           path: value
+           path: value in setting

--- a/kugl/builtins/schemas/kubernetes.yaml
+++ b/kugl/builtins/schemas/kubernetes.yaml
@@ -29,11 +29,11 @@ create:
       - spec.taints as taint
     columns:
       - name: node_uid
-        path: node.metadata.uid
+        path: metadata.uid in node
         comment: node UID, from metadata.uid
       - name: key
-        path: taint.key
+        path: key in taint
         comment: taint key
       - name: effect
-        path: taint.effect
+        path: effect in taint
         comment: taint effect

--- a/kugl/builtins/schemas/kubernetes.yaml
+++ b/kugl/builtins/schemas/kubernetes.yaml
@@ -25,15 +25,15 @@ create:
   - table: node_taints
     resource: nodes
     row_source:
-      - items
-      - spec.taints
+      - items as node
+      - spec.taints as taint
     columns:
       - name: node_uid
-        path: ^metadata.uid
+        path: node.metadata.uid
         comment: node UID, from metadata.uid
       - name: key
-        path: key
+        path: taint.key
         comment: taint key
       - name: effect
-        path: effect
+        path: taint.effect
         comment: taint effect

--- a/kugl/builtins/schemas/kubernetes.yaml
+++ b/kugl/builtins/schemas/kubernetes.yaml
@@ -29,11 +29,11 @@ create:
       - spec.taints as taint
     columns:
       - name: node_uid
-        path: metadata.uid in node
+        from: metadata.uid in node
         comment: node UID, from metadata.uid
       - name: key
-        path: key in taint
+        from: key in taint
         comment: taint key
       - name: effect
-        path: effect in taint
+        from: effect in taint
         comment: taint effect

--- a/kugl/impl/config.py
+++ b/kugl/impl/config.py
@@ -2,6 +2,7 @@
 Pydantic models for configuration files.
 """
 
+import re
 from os.path import expandvars, expanduser
 from typing import Optional, Tuple, Callable, Union
 
@@ -146,7 +147,10 @@ class UserColumn(Column):
         if column.path and column.label:
             raise ValueError("cannot specify both path and label")
         elif column.path:
-            column._extractor = PathExtractor(column.name, column.type, column.path)
+            # Strip any 'in <name>' suffix before JMESPath compilation; scope resolution
+            # is deferred to rebuild_for_scope when scope names are known.
+            path_target = re.sub(r"\s+in\s+[a-zA-Z_][a-zA-Z0-9_]*$", "", column.path)
+            column._extractor = PathExtractor(column.name, column.type, path_target)
         elif column.label:
             if not isinstance(column.label, list):
                 column.label = [column.label]
@@ -168,7 +172,7 @@ class UserColumn(Column):
             if ref.scope_name is None:
                 fail(
                     f"Table '{table_name}', column '{self.name}': "
-                    f"path '{self.path}' must begin with a scope name "
+                    f"path '{self.path}' must end with 'in <name>' "
                     f"(one of: {sorted(scope_names)})"
                 )
             try:
@@ -184,7 +188,7 @@ class UserColumn(Column):
                 if ref.scope_name is None:
                     fail(
                         f"Table '{table_name}', column '{self.name}': "
-                        f"label '{label}' must begin with a scope name "
+                        f"label '{label}' must end with 'in <name>' "
                         f"(one of: {sorted(scope_names)})"
                     )
                 if scope_name and scope_name != ref.scope_name:

--- a/kugl/impl/config.py
+++ b/kugl/impl/config.py
@@ -3,14 +3,13 @@ Pydantic models for configuration files.
 """
 
 from os.path import expandvars, expanduser
-import re
 from typing import Optional, Tuple, Callable, Union
 
 import jmespath
 from pydantic import BaseModel, ConfigDict, ValidationError
 from pydantic.functional_validators import model_validator
 
-from .extract import ColumnType, KUGL_TYPE_TO_SQL_TYPE, LabelExtractor, PathExtractor
+from .extract import ColumnType, KUGL_TYPE_TO_SQL_TYPE, FieldRef, LabelExtractor, PathExtractor
 from kugl.util import (
     Age,
     ConfigPath,
@@ -164,19 +163,16 @@ class UserColumn(Column):
 
         Called at TableFromConfig build time when scope names are known.
         """
-        _SCOPE_PREFIX = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\.(.+)$")
         if self.path:
-            m = _SCOPE_PREFIX.match(self.path)
-            if m and m.group(1) in scope_names:
-                scope_name, target = m.group(1), m.group(2)
-            else:
+            ref = FieldRef.parse_scoped(self.path, scope_names)
+            if ref.scope_name is None:
                 fail(
                     f"Table '{table_name}', column '{self.name}': "
                     f"path '{self.path}' must begin with a scope name "
                     f"(one of: {sorted(scope_names)})"
                 )
             try:
-                self._extractor = PathExtractor(self.name, self.type, target, scope_name=scope_name)
+                self._extractor = PathExtractor(self.name, self.type, ref.target, scope_name=ref.scope_name)
             except ValueError as e:
                 fail(str(e))
         elif self.label:
@@ -184,21 +180,20 @@ class UserColumn(Column):
             scope_name = None
             stripped_labels = []
             for label in labels:
-                m = _SCOPE_PREFIX.match(label)
-                if m and m.group(1) in scope_names:
-                    if scope_name and scope_name != m.group(1):
-                        fail(
-                            f"Table '{table_name}', column '{self.name}': "
-                            f"all labels must use the same scope name"
-                        )
-                    scope_name = m.group(1)
-                    stripped_labels.append(m.group(2))
-                else:
+                ref = FieldRef.parse_scoped(label, scope_names)
+                if ref.scope_name is None:
                     fail(
                         f"Table '{table_name}', column '{self.name}': "
                         f"label '{label}' must begin with a scope name "
                         f"(one of: {sorted(scope_names)})"
                     )
+                if scope_name and scope_name != ref.scope_name:
+                    fail(
+                        f"Table '{table_name}', column '{self.name}': "
+                        f"all labels must use the same scope name"
+                    )
+                scope_name = ref.scope_name
+                stripped_labels.append(ref.target)
             self._extractor = LabelExtractor(self.name, self.type, stripped_labels, scope_name=scope_name)
 
 

--- a/kugl/impl/config.py
+++ b/kugl/impl/config.py
@@ -7,10 +7,10 @@ from os.path import expandvars, expanduser
 from typing import Optional, Tuple, Callable, Union
 
 import jmespath
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from pydantic.functional_validators import model_validator
 
-from .extract import ColumnType, KUGL_TYPE_TO_SQL_TYPE, FieldRef, LabelExtractor, PathExtractor
+from .extract import ColumnType, KUGL_TYPE_TO_SQL_TYPE, FieldRef, LabelExtractor, PathExtractor, is_label
 from kugl.util import (
     Age,
     ConfigPath,
@@ -125,9 +125,10 @@ class Column(BaseModel):
 class UserColumn(Column):
     """Holds one entry from a columns: list in a user config file."""
 
-    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True, populate_by_name=True)
     path: Optional[str] = None
     label: Optional[Union[str, list[str]]] = None
+    from_: Optional[str] = Field(None, alias="from")
     # Parsed value of self.path
     _finder: jmespath.parser.Parser
     # Number of ^ in self.path
@@ -144,19 +145,33 @@ class UserColumn(Column):
         Generate the Extractor instance for a column definition; given an object, it will return
         a column value of the appropriate type.
         """
-        if column.path and column.label:
+        has_path = column.path is not None
+        has_label = column.label is not None
+        has_from = column.from_ is not None
+
+        if has_from and (has_path or has_label):
+            raise ValueError("cannot specify 'from' alongside 'path' or 'label'")
+        if has_path and has_label:
             raise ValueError("cannot specify both path and label")
-        elif column.path:
+
+        if has_from:
+            # Strip any 'in <name>' suffix; scope validation is deferred to rebuild_for_scope.
+            target = re.sub(r"\s+in\s+[a-zA-Z_][a-zA-Z0-9_]*$", "", column.from_)
+            if is_label(target):
+                column._extractor = LabelExtractor(column.name, column.type, [target])
+            else:
+                column._extractor = PathExtractor(column.name, column.type, target)
+        elif has_path:
             # Strip any 'in <name>' suffix before JMESPath compilation; scope resolution
             # is deferred to rebuild_for_scope when scope names are known.
             path_target = re.sub(r"\s+in\s+[a-zA-Z_][a-zA-Z0-9_]*$", "", column.path)
             column._extractor = PathExtractor(column.name, column.type, path_target)
-        elif column.label:
+        elif has_label:
             if not isinstance(column.label, list):
                 column.label = [column.label]
             column._extractor = LabelExtractor(column.name, column.type, column.label)
         else:
-            raise ValueError("must specify either path or label")
+            raise ValueError("must specify path, label, or from")
         return column
 
     def extract(self, obj: object, context) -> object:
@@ -199,6 +214,21 @@ class UserColumn(Column):
                 scope_name = ref.scope_name
                 stripped_labels.append(ref.target)
             self._extractor = LabelExtractor(self.name, self.type, stripped_labels, scope_name=scope_name)
+        elif self.from_:
+            ref = FieldRef.parse_scoped(self.from_, scope_names)
+            if ref.scope_name is None:
+                fail(
+                    f"Table '{table_name}', column '{self.name}': "
+                    f"'from' value '{self.from_}' must end with 'in <name>' "
+                    f"(one of: {sorted(scope_names)})"
+                )
+            if is_label(ref.target):
+                self._extractor = LabelExtractor(self.name, self.type, [ref.target], scope_name=ref.scope_name)
+            else:
+                try:
+                    self._extractor = PathExtractor(self.name, self.type, ref.target, scope_name=ref.scope_name)
+                except ValueError as e:
+                    fail(str(e))
 
 
 class ExtendTable(BaseModel):

--- a/kugl/impl/config.py
+++ b/kugl/impl/config.py
@@ -3,6 +3,7 @@ Pydantic models for configuration files.
 """
 
 from os.path import expandvars, expanduser
+import re
 from typing import Optional, Tuple, Callable, Union
 
 import jmespath
@@ -157,6 +158,48 @@ class UserColumn(Column):
 
     def extract(self, obj: object, context) -> object:
         return self._extractor(obj, context)
+
+    def rebuild_for_scope(self, scope_names: set, table_name: str):
+        """Re-create the extractor with scope awareness for multi-step row_source tables.
+
+        Called at TableFromConfig build time when scope names are known.
+        """
+        _SCOPE_PREFIX = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\.(.+)$")
+        if self.path:
+            m = _SCOPE_PREFIX.match(self.path)
+            if m and m.group(1) in scope_names:
+                scope_name, target = m.group(1), m.group(2)
+            else:
+                fail(
+                    f"Table '{table_name}', column '{self.name}': "
+                    f"path '{self.path}' must begin with a scope name "
+                    f"(one of: {sorted(scope_names)})"
+                )
+            try:
+                self._extractor = PathExtractor(self.name, self.type, target, scope_name=scope_name)
+            except ValueError as e:
+                fail(str(e))
+        elif self.label:
+            labels = self.label if isinstance(self.label, list) else [self.label]
+            scope_name = None
+            stripped_labels = []
+            for label in labels:
+                m = _SCOPE_PREFIX.match(label)
+                if m and m.group(1) in scope_names:
+                    if scope_name and scope_name != m.group(1):
+                        fail(
+                            f"Table '{table_name}', column '{self.name}': "
+                            f"all labels must use the same scope name"
+                        )
+                    scope_name = m.group(1)
+                    stripped_labels.append(m.group(2))
+                else:
+                    fail(
+                        f"Table '{table_name}', column '{self.name}': "
+                        f"label '{label}' must begin with a scope name "
+                        f"(one of: {sorted(scope_names)})"
+                    )
+            self._extractor = LabelExtractor(self.name, self.type, stripped_labels, scope_name=scope_name)
 
 
 class ExtendTable(BaseModel):

--- a/kugl/impl/extract.py
+++ b/kugl/impl/extract.py
@@ -36,7 +36,7 @@ KUGL_TYPE_TO_SQL_TYPE = {
 }
 
 
-_SCOPE_PREFIX = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\.(.+)$")
+_SCOPE_SUFFIX = re.compile(r"^(.+)\s+in\s+([a-zA-Z_][a-zA-Z0-9_]*)$")
 
 
 @dataclass
@@ -48,16 +48,16 @@ class FieldRef:
 
     @classmethod
     def parse_scoped(cls, s: str, scope_names: set) -> "FieldRef":
-        """Parse a path/label string, detecting a scope prefix if it matches a declared scope name.
+        """Parse a path/label string, detecting a trailing 'in <name>' scope qualifier.
 
-        Returns FieldRef with scope_name=None if the leading word is not a declared scope,
+        Returns FieldRef with scope_name=None if no matching qualifier is found,
         leaving the full string as the target.
         """
         if "^" in s:
             fail("^ parent navigation is no longer supported; use named row_source scopes instead")
-        m = _SCOPE_PREFIX.match(s)
-        if m and m.group(1) in scope_names:
-            return cls(m.group(1), m.group(2))
+        m = _SCOPE_SUFFIX.match(s)
+        if m and m.group(2) in scope_names:
+            return cls(m.group(2), m.group(1))
         return cls(None, s)
 
 

--- a/kugl/impl/extract.py
+++ b/kugl/impl/extract.py
@@ -36,6 +36,9 @@ KUGL_TYPE_TO_SQL_TYPE = {
 }
 
 
+_SCOPE_PREFIX = re.compile(r"^([a-zA-Z_][a-zA-Z0-9_]*)\.(.+)$")
+
+
 @dataclass
 class FieldRef:
     """Parsed form of a potentially-scoped JMESPath expression or label."""
@@ -48,6 +51,20 @@ class FieldRef:
         """Parse a path/label string, raising if ^ syntax is used."""
         if "^" in s:
             fail("^ parent navigation is no longer supported; use named row_source scopes instead")
+        return cls(None, s)
+
+    @classmethod
+    def parse_scoped(cls, s: str, scope_names: set) -> "FieldRef":
+        """Parse a path/label string, detecting a scope prefix if it matches a declared scope name.
+
+        Returns FieldRef with scope_name=None if the leading word is not a declared scope,
+        leaving the full string as the target.
+        """
+        if "^" in s:
+            fail("^ parent navigation is no longer supported; use named row_source scopes instead")
+        m = _SCOPE_PREFIX.match(s)
+        if m and m.group(1) in scope_names:
+            return cls(m.group(1), m.group(2))
         return cls(None, s)
 
 

--- a/kugl/impl/extract.py
+++ b/kugl/impl/extract.py
@@ -47,13 +47,6 @@ class FieldRef:
     target: str
 
     @classmethod
-    def parse(cls, s: str) -> "FieldRef":
-        """Parse a path/label string, raising if ^ syntax is used."""
-        if "^" in s:
-            fail("^ parent navigation is no longer supported; use named row_source scopes instead")
-        return cls(None, s)
-
-    @classmethod
     def parse_scoped(cls, s: str, scope_names: set) -> "FieldRef":
         """Parse a path/label string, detecting a scope prefix if it matches a declared scope name.
 

--- a/kugl/impl/extract.py
+++ b/kugl/impl/extract.py
@@ -37,6 +37,12 @@ KUGL_TYPE_TO_SQL_TYPE = {
 
 
 _SCOPE_SUFFIX = re.compile(r"^(.+)\s+in\s+([a-zA-Z_][a-zA-Z0-9_]*)$")
+_LABEL_PATTERN = re.compile(r"^[a-zA-Z0-9.-]+/[a-zA-Z0-9._/-]+$")
+
+
+def is_label(s: str) -> bool:
+    """Return True if s looks like a Kubernetes label key (domain/name format)."""
+    return bool(_LABEL_PATTERN.match(s))
 
 
 @dataclass
@@ -56,8 +62,10 @@ class FieldRef:
         if "^" in s:
             fail("^ parent navigation is no longer supported; use named row_source scopes instead")
         m = _SCOPE_SUFFIX.match(s)
-        if m and m.group(2) in scope_names:
-            return cls(m.group(2), m.group(1))
+        if m:
+            if m.group(2) in scope_names:
+                return cls(m.group(2), m.group(1))
+            fail(f"Unknown scope '{m.group(2)}'; valid scopes are: {sorted(scope_names)}")
         return cls(None, s)
 
 

--- a/kugl/impl/extract.py
+++ b/kugl/impl/extract.py
@@ -5,14 +5,13 @@ Formerly in ./config.py, refactored for clarity.
 
 from dataclasses import dataclass
 import re
-from typing import Literal
+from typing import Literal, Optional
 
 import jmespath
 
 from kugl.util import parse_utc, parse_age, parse_size, parse_cpu, abbreviate, fail
 
 ColumnType = Literal["text", "integer", "real", "date", "age", "size", "cpu"]
-PARENTED_PATH = re.compile(r"^(\^*)(.*)")
 
 KUGL_TYPE_CONVERTERS = {
     # Valid choices for column type in config -> function to extract that from a string
@@ -39,15 +38,17 @@ KUGL_TYPE_TO_SQL_TYPE = {
 
 @dataclass
 class FieldRef:
-    """Parsed form of a parented JMESPath expression or label, e.g. '^^metadata.name'"""
+    """Parsed form of a potentially-scoped JMESPath expression or label."""
 
-    n_parents: int
+    scope_name: Optional[str]
     target: str
 
     @classmethod
-    def parse(cls, s):
-        m = PARENTED_PATH.match(s)
-        return cls(len(m.group(1)), m.group(2))
+    def parse(cls, s: str) -> "FieldRef":
+        """Parse a path/label string, raising if ^ syntax is used."""
+        if "^" in s:
+            fail("^ parent navigation is no longer supported; use named row_source scopes instead")
+        return cls(None, s)
 
 
 class Extractor:
@@ -81,22 +82,28 @@ class Extractor:
 class LabelExtractor(Extractor):
     """Extract a column value from the first matching label in a list of labels."""
 
-    def __init__(self, column_name: str, column_type: ColumnType, labels: list[str]):
+    def __init__(self, column_name: str, column_type: ColumnType, labels: list[str],
+                 scope_name: Optional[str] = None):
         super().__init__(column_name, column_type)
+        for label in labels:
+            if "^" in label:
+                raise ValueError(
+                    f"^ parent navigation is no longer supported in column {column_name}; "
+                    f"use named row_source scopes instead"
+                )
         self._labels = labels
-        self._refs = [FieldRef.parse(label) for label in labels]
+        self._scope_name = scope_name
 
     def extract(self, obj: object, context) -> object:
         """Resolve the metadata location for each label and see if the label is present."""
-        for ref in self._refs:
-            if ref.n_parents > 0:
-                obj = context.get_parent(obj, ref.n_parents)
+        if self._scope_name:
+            obj = context.get_scope(obj, self._scope_name)
             if obj is None:
-                fail(f"Missing parent or too many ^ while evaluating {ref.target}")
-            if available := obj.get("metadata", {}).get("labels", {}):
-                # If the label is present here, return the value here, even if null
-                if ref.target in available:
-                    return available[ref.target]
+                fail(f"Unknown scope '{self._scope_name}' for column '{self.column_name}'")
+        if available := obj.get("metadata", {}).get("labels", {}):
+            for label in self._labels:
+                if label in available:
+                    return available[label]
 
     def __str__(self):
         """For debug output"""
@@ -106,23 +113,29 @@ class LabelExtractor(Extractor):
 class PathExtractor(Extractor):
     """Extract a column value from the target of a JMESPath expression."""
 
-    def __init__(self, column_name: str, column_type: ColumnType, path: str):
+    def __init__(self, column_name: str, column_type: ColumnType, path: str,
+                 scope_name: Optional[str] = None):
         super().__init__(column_name, column_type)
-        self._ref = FieldRef.parse(path)
+        if "^" in path:
+            raise ValueError(
+                f"^ parent navigation is no longer supported in column {column_name}; "
+                f"use named row_source scopes instead"
+            )
+        self._scope_name = scope_name
         self._path = path
         try:
-            self._finder = jmespath.compile(self._ref.target)
+            self._finder = jmespath.compile(path)
         except jmespath.exceptions.ParseError as e:
             raise ValueError(
-                f"invalid JMESPath expression {self._ref.target} in column {column_name}"
+                f"invalid JMESPath expression {path} in column {column_name}"
             ) from e
 
     def extract(self, obj: object, context) -> object:
         """Extract a value from an object using a JMESPath finder."""
-        if self._ref.n_parents > 0:
-            obj = context.get_parent(obj, self._ref.n_parents)
-        if obj is None:
-            fail(f"Missing parent or too many ^ while evaluating {self._path}")
+        if self._scope_name:
+            obj = context.get_scope(obj, self._scope_name)
+            if obj is None:
+                fail(f"Unknown scope '{self._scope_name}' for column '{self.column_name}'")
         return self._finder.search(obj)
 
     def __str__(self):

--- a/kugl/impl/tables.py
+++ b/kugl/impl/tables.py
@@ -220,11 +220,13 @@ class RowContext:
             depth -= 1
         return child
 
+    # FIXME: rethink how this is done
     def set_scope(self, child, name: str, parent=None):
         """Register child as the named scope, inheriting ancestor scopes from parent."""
         base = self._scopes.get(id(parent), {}) if parent is not None else {}
         self.set_scope_with_base(child, name, base)
 
+    # FIXME: rethink how this is done
     def set_scope_with_base(self, child, name: str, base: dict):
         """Like set_scope but accepts a pre-computed base scope dict."""
         self._scopes[id(child)] = {**base, name: child}

--- a/kugl/impl/tables.py
+++ b/kugl/impl/tables.py
@@ -131,8 +131,8 @@ class TableFromConfig(Table):
         )
         self.row_source = [Itemizer.parse(x, name) for x in (creator.row_source or ["items"])]
         if len(self.row_source) > 1:
-            scope_names = {s.name for s in self.row_source if s.name is not None}
-            unnamed = [s.expr for s in self.row_source if s.name is None]
+            scope_names = {s.scope_name for s in self.row_source if s.scope_name is not None}
+            unnamed = [s.expr for s in self.row_source if s.scope_name is None]
             if unnamed:
                 fail(
                     f"Table '{name}': multi-step row_source entries must all have 'as <name>'; "
@@ -176,8 +176,8 @@ class TableFromConfig(Table):
                             # Fix #132 -- don't do this at pass 0, or it sets the parent to the entire
                             # response object.
                             context.set_parent(child, item)
-                        if source.name is not None:
-                            context.set_scope(child, source.name, item if index > 0 else None)
+                        if source.scope_name is not None:
+                            context.set_scope(child, source.scope_name, item if index > 0 else None)
                         new_items.append(child)
                         if debug:
                             debug("add " + abbreviate(child))
@@ -185,8 +185,8 @@ class TableFromConfig(Table):
                     if index > 0:
                         # See comment above.
                         context.set_parent(found, item)
-                    if source.name is not None:
-                        context.set_scope(found, source.name, item if index > 0 else None)
+                    if source.scope_name is not None:
+                        context.set_scope(found, source.scope_name, item if index > 0 else None)
                     new_items.append(found)
                     if debug:
                         debug("add " + abbreviate(found))
@@ -241,7 +241,7 @@ class Itemizer:
     # Should dictionaries be unpacked to a key/value array
     unpack: bool
     # Optional scope name from 'as <name>' suffix
-    name: Optional[str] = None
+    scope_name: Optional[str] = None
 
     @classmethod
     def parse(cls, s: str, table_name: str):
@@ -269,6 +269,6 @@ class Itemizer:
                 fail(f"Invalid scope name '{name}' in row_source: {s}")
 
         try:
-            return Itemizer(expr=expr_part, finder=jmespath.compile(expr_part), unpack=unpack, name=name)
+            return Itemizer(expr=expr_part, finder=jmespath.compile(expr_part), unpack=unpack, scope_name=name)
         except jmespath.exceptions.ParseError as e:
             fail(f"invalid row_source {expr_part} for table {table_name}", e)

--- a/kugl/impl/tables.py
+++ b/kugl/impl/tables.py
@@ -171,13 +171,15 @@ class TableFromConfig(Table):
                 if isinstance(found, dict) and source.unpack:
                     found = [{"key": k, "value": v} for k, v in found.items()]
                 if isinstance(found, list):
+                    # Compute base scopes once for all children from this item.
+                    base_scopes = (context._scopes.get(id(item), {}) if index > 0 else {}) if source.scope_name else None
                     for child in found:
                         if index > 0:
                             # Fix #132 -- don't do this at pass 0, or it sets the parent to the entire
                             # response object.
                             context.set_parent(child, item)
                         if source.scope_name is not None:
-                            context.set_scope(child, source.scope_name, item if index > 0 else None)
+                            context.set_scope_with_base(child, source.scope_name, base_scopes)
                         new_items.append(child)
                         if debug:
                             debug("add " + abbreviate(child))
@@ -220,10 +222,12 @@ class RowContext:
 
     def set_scope(self, child, name: str, parent=None):
         """Register child as the named scope, inheriting ancestor scopes from parent."""
-        parent_scopes = self._scopes.get(id(parent), {}) if parent is not None else {}
-        child_scopes = dict(parent_scopes)
-        child_scopes[name] = child
-        self._scopes[id(child)] = child_scopes
+        base = self._scopes.get(id(parent), {}) if parent is not None else {}
+        self.set_scope_with_base(child, name, base)
+
+    def set_scope_with_base(self, child, name: str, base: dict):
+        """Like set_scope but accepts a pre-computed base scope dict."""
+        self._scopes[id(child)] = {**base, name: child}
 
     def get_scope(self, obj, name: str):
         """Look up a named scope for obj, returning None if not found."""

--- a/kugl/impl/tables.py
+++ b/kugl/impl/tables.py
@@ -4,6 +4,7 @@ SQLite tables are defined and populated here.
 """
 
 from dataclasses import dataclass
+import re
 from typing import Optional, Type
 
 import jmespath
@@ -129,6 +130,16 @@ class TableFromConfig(Table):
             creator.columns + (extender.columns if extender else []),
         )
         self.row_source = [Itemizer.parse(x, name) for x in (creator.row_source or ["items"])]
+        if len(self.row_source) > 1:
+            scope_names = {s.name for s in self.row_source if s.name is not None}
+            unnamed = [s.expr for s in self.row_source if s.name is None]
+            if unnamed:
+                fail(
+                    f"Table '{name}': multi-step row_source entries must all have 'as <name>'; "
+                    f"missing for: {unnamed}"
+                )
+            for column in self.added_columns:
+                column.rebuild_for_scope(scope_names, name)
 
     def make_rows(self, context: "RowContext") -> list[tuple[dict, tuple]]:
         """
@@ -165,6 +176,8 @@ class TableFromConfig(Table):
                             # Fix #132 -- don't do this at pass 0, or it sets the parent to the entire
                             # response object.
                             context.set_parent(child, item)
+                        if source.name is not None:
+                            context.set_scope(child, source.name, item if index > 0 else None)
                         new_items.append(child)
                         if debug:
                             debug("add " + abbreviate(child))
@@ -172,6 +185,8 @@ class TableFromConfig(Table):
                     if index > 0:
                         # See comment above.
                         context.set_parent(found, item)
+                    if source.name is not None:
+                        context.set_scope(found, source.name, item if index > 0 else None)
                     new_items.append(found)
                     if debug:
                         debug("add " + abbreviate(found))
@@ -184,12 +199,15 @@ class RowContext:
 
     Primarily, the `.data` attribute holds the JSON data from 'kubectl get' or similar.
     The `.set_parent` and `.get_parent` methods allow row-generating functions to track
-    parent objects as they iterate through nested data structures."""
+    parent objects as they iterate through nested data structures.
+    The `.set_scope` and `.get_scope` methods support named scope resolution for
+    multi-step row_source tables."""
 
     def __init__(self, data):
         self.data = data
         self.debug = debugging("extract")
         self._parents = {}
+        self._scopes = {}
 
     def set_parent(self, child, parent):
         self._parents[id(child)] = parent
@@ -200,21 +218,38 @@ class RowContext:
             depth -= 1
         return child
 
+    def set_scope(self, child, name: str, parent=None):
+        """Register child as the named scope, inheriting ancestor scopes from parent."""
+        parent_scopes = self._scopes.get(id(parent), {}) if parent is not None else {}
+        child_scopes = dict(parent_scopes)
+        child_scopes[name] = child
+        self._scopes[id(child)] = child_scopes
+
+    def get_scope(self, obj, name: str):
+        """Look up a named scope for obj, returning None if not found."""
+        return self._scopes.get(id(obj), {}).get(name)
+
 
 @dataclass
 class Itemizer:
     """Helper class to hold information parsed from one line of a row_source"""
 
-    # Original row_source expression
+    # JMESPath expression (without the 'as <name>' suffix)
     expr: str
     # JMESPath expression to find the items
     finder: ParsedResult
     # Should dictionaries be unpacked to a key/value array
     unpack: bool
+    # Optional scope name from 'as <name>' suffix
+    name: Optional[str] = None
 
     @classmethod
     def parse(cls, s: str, table_name: str):
-        """Parse a line from the row_source section of a config file"""
+        """Parse a line from the row_source section of a config file.
+
+        Syntax: 'expr [as name][; kv]'
+        """
+        # Split off options (;kv etc.)
         parts = s.split(";")
         if len(parts) == 1:
             unpack = False
@@ -222,7 +257,18 @@ class Itemizer:
             unpack = True
         else:
             fail(f"Invalid row_source options: {s}")
+
+        # Parse 'expr as name' from the expression part
+        expr_part = parts[0].strip()
+        name = None
+        as_index = expr_part.find(" as ")
+        if as_index >= 0:
+            name = expr_part[as_index + 4:].strip()
+            expr_part = expr_part[:as_index].strip()
+            if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", name):
+                fail(f"Invalid scope name '{name}' in row_source: {s}")
+
         try:
-            return Itemizer(s, jmespath.compile(parts[0]), unpack)
+            return Itemizer(expr=expr_part, finder=jmespath.compile(expr_part), unpack=unpack, name=name)
         except jmespath.exceptions.ParseError as e:
-            fail(f"invalid row_source {parts[0]} for table {table_name}", e)
+            fail(f"invalid row_source {expr_part} for table {table_name}", e)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -201,4 +201,4 @@ def test_must_have_path_or_label():
     """),
         return_errors=True,
     )
-    assert errors == ["columns.0: Value error, must specify either path or label"]
+    assert errors == ["columns.0: Value error, must specify path, label, or from"]

--- a/tests/k8s/test_jobs.py
+++ b/tests/k8s/test_jobs.py
@@ -81,9 +81,9 @@ def test_label_parents(test_home):
               - spec.template as template
             columns:
               - name: job_username
-                label: job.user
+                label: user in job
               - name: pod_username
-                label: template.user
+                label: user in template
     """)
     kubectl_response(
         "jobs",

--- a/tests/k8s/test_jobs.py
+++ b/tests/k8s/test_jobs.py
@@ -77,13 +77,13 @@ def test_label_parents(test_home):
           - table: job_users
             resource: jobs
             row_source:
-              - items
-              - spec.template
+              - items as job
+              - spec.template as template
             columns:
               - name: job_username
-                label: ^user
+                label: job.user
               - name: pod_username
-                label: user
+                label: template.user
     """)
     kubectl_response(
         "jobs",

--- a/tests/resource/test_folder.py
+++ b/tests/resource/test_folder.py
@@ -74,9 +74,12 @@ def test_folder_content(hr, tmp_path, capsys):
         match="(?P<region>[^/]+)/data.yaml",
     )
     # Update the row_source of the people table to match the folder data layout.
-    config["create"][0]["row_source"] = ["[]", "content"]
-    # Add a column to capture the region.
-    config["create"][0]["columns"].append(dict(name="region", path="^match.region"))
+    config["create"][0]["row_source"] = ["[] as file", "content as person"]
+    config["create"][0]["columns"] = [
+        dict(name="name", path="person.name"),
+        dict(name="age", path="person.age", type="integer"),
+        dict(name="region", path="file.match.region"),
+    ]
     hr.save(config)
     with features_debugged("folder"):
         assert_query(

--- a/tests/resource/test_folder.py
+++ b/tests/resource/test_folder.py
@@ -76,9 +76,9 @@ def test_folder_content(hr, tmp_path, capsys):
     # Update the row_source of the people table to match the folder data layout.
     config["create"][0]["row_source"] = ["[] as file", "content as person"]
     config["create"][0]["columns"] = [
-        dict(name="name", path="person.name"),
-        dict(name="age", path="person.age", type="integer"),
-        dict(name="region", path="file.match.region"),
+        dict(name="name", path="name in person"),
+        dict(name="age", path="age in person", type="integer"),
+        dict(name="region", path="match.region in file"),
     ]
     hr.save(config)
     with features_debugged("folder"):

--- a/tests/resource/test_row_source.py
+++ b/tests/resource/test_row_source.py
@@ -42,9 +42,9 @@ _MULTI_STEP_CONFIG = """
         - children as child
       columns:
         - name: parent_id
-          path: item.parent
+          path: parent in item
         - name: val
-          path: child.val
+          path: val in child
 """
 
 @pytest.mark.parametrize("items,expected", [
@@ -103,11 +103,11 @@ def test_kv_with_parent_nav(test_home):
             - env as kv_pair; kv
           columns:
             - name: service
-              path: item.service
+              path: service in item
             - name: key
-              path: kv_pair.key
+              path: key in kv_pair
             - name: value
-              path: kv_pair.value
+              path: value in kv_pair
     """)
     assert_query(
         "SELECT * FROM things ORDER BY service, key",
@@ -145,11 +145,11 @@ def test_three_level_named_scopes(test_home):
             - tags as tag_item
           columns:
             - name: section
-              path: section_item.section
+              path: section in section_item
             - name: grp
-              path: group.grp
+              path: grp in group
             - name: tag
-              path: tag_item.tag
+              path: tag in tag_item
     """)
     assert_query(
         "SELECT * FROM things ORDER BY section, grp, tag",
@@ -178,7 +178,7 @@ def test_missing_scope_name(test_home):
             - children
           columns:
             - name: val
-              path: item.val
+              path: val in item
     """)
     with pytest.raises(KuglError, match="must all have 'as <name>'"):
         assert_query("SELECT * FROM things", "")
@@ -202,7 +202,7 @@ def test_unscoped_column_in_multi_step(test_home):
             - name: val
               path: val
     """)
-    with pytest.raises(KuglError, match="must begin with a scope name"):
+    with pytest.raises(KuglError, match="must end with 'in <name>'"):
         assert_query("SELECT * FROM things", "")
 
 

--- a/tests/resource/test_row_source.py
+++ b/tests/resource/test_row_source.py
@@ -206,6 +206,154 @@ def test_unscoped_column_in_multi_step(test_home):
         assert_query("SELECT * FROM things", "")
 
 
+def test_from_detects_label(test_home):
+    """`from: domain/key` auto-detects as a label extractor."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - metadata:
+                  labels:
+                    test.io/group: team-a
+      create:
+        - table: things
+          resource: things
+          columns:
+            - name: grp
+              from: test.io/group
+    """)
+    assert_query("SELECT * FROM things", """
+        grp
+        team-a
+    """)
+
+
+def test_from_detects_path(test_home):
+    """`from: jmespath.expr` auto-detects as a path extractor."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - metadata:
+                  name: my-thing
+      create:
+        - table: things
+          resource: things
+          columns:
+            - name: thing_name
+              from: metadata.name
+    """)
+    assert_query("SELECT * FROM things", """
+        thing_name
+        my-thing
+    """)
+
+
+def test_from_scoped_path(test_home):
+    """`from: expr in scope` resolves a JMESPath on the named scope."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - metadata:
+                  name: pod-a
+                spec:
+                  containers:
+                    - name: c1
+                    - name: c2
+      create:
+        - table: things
+          resource: things
+          row_source:
+            - items as pod
+            - spec.containers as container
+          columns:
+            - name: pod_name
+              from: metadata.name in pod
+            - name: container_name
+              from: name in container
+    """)
+    assert_query("SELECT * FROM things ORDER BY container_name", """
+        pod_name    container_name
+        pod-a       c1
+        pod-a       c2
+    """)
+
+
+def test_from_scoped_label(test_home):
+    """`from: domain/key in scope` resolves as a label on the named scope object."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - metadata:
+                  labels:
+                    test.io/group: team-b
+                children:
+                  - val: x
+      create:
+        - table: things
+          resource: things
+          row_source:
+            - items as item
+            - children as child
+          columns:
+            - name: grp
+              from: test.io/group in item
+            - name: val
+              from: val in child
+    """)
+    assert_query("SELECT * FROM things", """
+        grp     val
+        team-b  x
+    """)
+
+
+def test_from_conflicts_with_path(test_home):
+    """Specifying both `from` and `path` raises a validation error."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items: [{val: a}]
+      create:
+        - table: things
+          resource: things
+          columns:
+            - name: val
+              from: val
+              path: val
+    """)
+    with pytest.raises(KuglError, match="cannot specify .from. alongside"):
+        assert_query("SELECT * FROM things", "")
+
+
+def test_from_unknown_scope(test_home):
+    """`from: expr in unknownscope` raises a clear error at table-build time."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - children: [{val: a}]
+      create:
+        - table: things
+          resource: things
+          row_source:
+            - items as item
+            - children as child
+          columns:
+            - name: val
+              from: val in ghost
+    """)
+    with pytest.raises(KuglError, match="Unknown scope 'ghost'"):
+        assert_query("SELECT * FROM things", "")
+
+
 def test_data_dict_expansion(test_home):
     """Verify the behavior of the '; kv' option in row_source"""
     kugl_home().prep().joinpath("kubernetes.yaml").write_text("""

--- a/tests/resource/test_row_source.py
+++ b/tests/resource/test_row_source.py
@@ -11,8 +11,8 @@ from ..testing import assert_query
 from ..k8s.k8s_mocks import kubectl_response
 
 
-def test_too_many_parents(test_home):
-    """Ensure correct error when a parent field reference is too long."""
+def test_caret_rejected(test_home):
+    """Ensure ^ parent navigation raises a clear error."""
     kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
       resources:
         - name: things
@@ -22,18 +22,10 @@ def test_too_many_parents(test_home):
           resource: things
           columns:
             - name: something
-              path: ^^^invalid
+              path: ^parent
     """)
-    kubectl_response(
-        "things",
-        {
-            "items": [
-                {"something": "foo"},
-                {"something": "foo"},
-            ]
-        },
-    )
-    with pytest.raises(KuglError, match="Missing parent or too many . while evaluating ...invalid"):
+    kubectl_response("things", {"items": [{"something": "foo"}]})
+    with pytest.raises(KuglError, match=r"\^ parent navigation is no longer supported"):
         assert_query("SELECT * FROM things", "")
 
 
@@ -46,13 +38,13 @@ _MULTI_STEP_CONFIG = """
     - table: things
       resource: things
       row_source:
-        - items
-        - children
+        - items as item
+        - children as child
       columns:
         - name: parent_id
-          path: ^parent
+          path: item.parent
         - name: val
-          path: val
+          path: child.val
 """
 
 @pytest.mark.parametrize("items,expected", [
@@ -82,7 +74,7 @@ _MULTI_STEP_CONFIG = """
     ),
 ])
 def test_multi_step_row_source(test_home, items, expected):
-    """Multi-step row_source with ^ parent navigation; also checks empty sublists produce no rows."""
+    """Multi-step row_source with named scopes; also checks empty sublists produce no rows."""
     kugl_home().prep().joinpath("kubernetes.yaml").write_text(
         _MULTI_STEP_CONFIG.format(items=json.dumps(items))
     )
@@ -90,7 +82,7 @@ def test_multi_step_row_source(test_home, items, expected):
 
 
 def test_kv_with_parent_nav(test_home):
-    """'; kv' expansion combined with ^ to reference a field from the parent item."""
+    """'; kv' expansion combined with named scope to reference a field from the parent item."""
     kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
       resources:
         - name: things
@@ -107,15 +99,15 @@ def test_kv_with_parent_nav(test_home):
         - table: things
           resource: things
           row_source:
-            - items
-            - env; kv
+            - items as item
+            - env as kv_pair; kv
           columns:
             - name: service
-              path: ^service
+              path: item.service
             - name: key
-              path: key
+              path: kv_pair.key
             - name: value
-              path: value
+              path: kv_pair.value
     """)
     assert_query(
         "SELECT * FROM things ORDER BY service, key",
@@ -128,8 +120,8 @@ def test_kv_with_parent_nav(test_home):
     )
 
 
-def test_double_parent_nav(test_home):
-    """^^ navigates two levels up through a three-step row_source chain."""
+def test_three_level_named_scopes(test_home):
+    """Three-step row_source with named scopes; verifies ancestor scopes are reachable."""
     kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
       resources:
         - name: things
@@ -148,16 +140,16 @@ def test_double_parent_nav(test_home):
         - table: things
           resource: things
           row_source:
-            - items
-            - groups
-            - tags
+            - items as section_item
+            - groups as group
+            - tags as tag_item
           columns:
             - name: section
-              path: ^^section
+              path: section_item.section
             - name: grp
-              path: ^grp
+              path: group.grp
             - name: tag
-              path: tag
+              path: tag_item.tag
     """)
     assert_query(
         "SELECT * FROM things ORDER BY section, grp, tag",
@@ -168,6 +160,50 @@ def test_double_parent_nav(test_home):
         sec-a      grp-2  t3
         """,
     )
+
+
+def test_missing_scope_name(test_home):
+    """Multi-step row_source without 'as <name>' raises a ConfigError."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - children: [{val: a}]
+      create:
+        - table: things
+          resource: things
+          row_source:
+            - items as item
+            - children
+          columns:
+            - name: val
+              path: item.val
+    """)
+    with pytest.raises(KuglError, match="must all have 'as <name>'"):
+        assert_query("SELECT * FROM things", "")
+
+
+def test_unscoped_column_in_multi_step(test_home):
+    """Multi-step row_source with a bare (un-scoped) column path raises a ConfigError."""
+    kugl_home().prep().joinpath("kubernetes.yaml").write_text("""
+      resources:
+        - name: things
+          data:
+            items:
+              - children: [{val: a}]
+      create:
+        - table: things
+          resource: things
+          row_source:
+            - items as item
+            - children as child
+          columns:
+            - name: val
+              path: val
+    """)
+    with pytest.raises(KuglError, match="must begin with a scope name"):
+        assert_query("SELECT * FROM things", "")
 
 
 def test_data_dict_expansion(test_home):


### PR DESCRIPTION
Replace ^ parent-hop syntax with named scope references. Multi-step row_source entries must carry 'as <name>', and column paths/labels must be prefixed with a declared scope name. Single-step tables are unchanged.