### PR TITLE
Implement positional parameters for shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Extending tables:
   ``domain/key`` format (e.g. ``karpenter.sh/nodepool``) use label extraction, everything
   else uses JMESPath (``path:`` and ``label:`` to be removed in a future release)
 
-Documentation:
+Other:
 
+- Shortcuts now support parameterization
 - New masthead example of ``kugl`` vs ``kubectl | jq``
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,22 @@ settings:
 shortcuts:
   - name: mypods
     args: ["select name, status from pods where namespace = 'default'"]
+  - name: pods-by-image
+    args: ["select name, namespace, status from pods where image like '%{{img}}%'"]
+    params:
+      - img
 ```
+
+Shortcuts support positional parameters via `{{name}}` tokens in `args`. Declare param names in
+`params:`; supply values at invocation time as trailing positional arguments:
+
+```
+kugl pods-by-image nginx
+kugl -H pods-by-image nginx   # flags before the shortcut name still work
+```
+
+Config validation fails at parse time if a `{{token}}` appears in `args` but is not listed in
+`params`. Invocation fails with a clear error if the wrong number of arguments is supplied.
 
 ### `~/.kugl/<schema>.yaml` (e.g. `kubernetes.yaml`)
 Defines resources and tables for a schema.

--- a/docs/shortcuts.rst
+++ b/docs/shortcuts.rst
@@ -37,6 +37,33 @@ in `recommended configuration <./recommended.rst>`__, add this to
 
 To run, type ``kugl hi-mem`` or ``kugl nodes``.
 
-Simple parameter substitution might be offered in the future, but if you
-need more powerful templates, your own wrapper script is the short-term
-answer.
+Parameterized shortcuts
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Shortcuts can declare named parameters, letting a single shortcut serve
+multiple invocations with different values.
+
+Declare parameter names in the ``params`` list and reference them in
+``args`` as ``{{name}}`` tokens:
+
+.. code:: yaml
+
+   shortcuts:
+
+     - name: pods-by-image
+       args:
+         - "SELECT name, namespace, status FROM pods WHERE image LIKE '%{{img}}%'"
+       params:
+         - img
+
+Supply values positionally on the command line:
+
+.. code:: bash
+
+   kugl pods-by-image nginx
+   kugl -H pods-by-image nginx     # flags before the shortcut name still work
+
+The number of positional arguments must match the number of declared
+parameters exactly; a mismatch is an error.  Using a ``{{token}}`` in
+``args`` without a matching entry in ``params`` is also an error, caught
+at config-load time.

--- a/kugl/impl/config.py
+++ b/kugl/impl/config.py
@@ -73,6 +73,17 @@ class Shortcut(BaseModel):
     name: str
     args: list[str]
     comment: Optional[str] = None
+    params: list[str] = []
+
+    @model_validator(mode="after")
+    @classmethod
+    def _check_params(cls, shortcut: "Shortcut") -> "Shortcut":
+        declared = set(shortcut.params)
+        for arg in shortcut.args:
+            for token in re.findall(r'\{\{(\w+)\}\}', arg):
+                if token not in declared:
+                    fail(f"Shortcut '{shortcut.name}': undeclared parameter '{{{{{token}}}}}'")
+        return shortcut
 
 
 class SecondaryUserInit(ConfigContent):

--- a/kugl/main.py
+++ b/kugl/main.py
@@ -4,6 +4,7 @@ Command-line entry point.
 
 import argparse
 import os
+import re
 from argparse import ArgumentParser
 import sys
 from sqlite3 import DatabaseError
@@ -80,13 +81,28 @@ def main2(argv: List[str], init: Optional[UserInit] = None):
 
     ap = ArgumentParser()
     Registry.get().augment_cli(ap)
-    args, cache_flag = parse_args(argv, ap, init.settings)
+    args, cache_flag, extras = parse_args(argv, ap, init.settings)
+
+    # Reject unrecognized options for direct SQL queries (shortcuts handle this separately).
+    if " " in args.sql and extras:
+        ap.error(f"unrecognized arguments: {' '.join(extras)}")
 
     # Check for shortcut and reparse, because they can contain command-line options.
     if " " not in args.sql:
         if not (shortcut := shortcuts.get(args.sql)):
             fail(f"No shortcut named '{args.sql}' is defined")
-        return main2(argv[:-1] + shortcut.args, init)
+        bad = [e for e in extras if e.startswith('-')]
+        if bad:
+            fail(f"Unrecognized options: {' '.join(bad)}")
+        if len(extras) != len(shortcut.params):
+            if shortcut.params:
+                fail(f"Shortcut '{shortcut.name}' requires {len(shortcut.params)} argument(s): {', '.join(shortcut.params)}")
+            else:
+                fail(f"Shortcut '{shortcut.name}' takes no arguments")
+        bindings = dict(zip(shortcut.params, extras))
+        expanded = [re.sub(r'\{\{(\w+)\}\}', lambda m: bindings[m.group(1)], a) for a in shortcut.args]
+        base = [a for a in argv if a not in set(extras) and a != args.sql]
+        return main2(base + expanded, init)
 
     if args.debug:
         debug_features(args.debug.split(","))
@@ -99,7 +115,7 @@ def main2(argv: List[str], init: Optional[UserInit] = None):
 
 def parse_args(
     argv: list[str], ap: ArgumentParser, settings: Settings
-) -> tuple[argparse.Namespace, CacheFlag]:
+) -> tuple[argparse.Namespace, CacheFlag, list[str]]:
     """Add stock arguments to parser, parse the command line, and override settings."""
     ap.add_argument("-c", "--context", type=str)
     ap.add_argument("-D", "--debug", type=str)
@@ -109,7 +125,7 @@ def parse_args(
     ap.add_argument("-s", "--stale", default=False, action="store_true")
     ap.add_argument("-t", "--timeout", type=str)
     ap.add_argument("sql")
-    args = ap.parse_args(argv)
+    args, extras = ap.parse_known_args(argv)
     if args.stale and args.refresh:
         fail("Cannot use both -s/--stale and -r/--refresh")
     if args.timeout:
@@ -118,7 +134,7 @@ def parse_args(
         settings.quiet = True
     if args.no_headers:
         settings.no_headers = True
-    return args, (ALWAYS_UPDATE if args.refresh else NEVER_UPDATE if args.stale else CHECK)
+    return args, (ALWAYS_UPDATE if args.refresh else NEVER_UPDATE if args.stale else CHECK), extras
 
 
 def _merge_init_files() -> tuple[UserInit, dict[str, Shortcut]]:

--- a/kugl/main.py
+++ b/kugl/main.py
@@ -101,8 +101,8 @@ def main2(argv: List[str], init: Optional[UserInit] = None):
                 fail(f"Shortcut '{shortcut.name}' takes no arguments")
         bindings = dict(zip(shortcut.params, extras))
         expanded = [re.sub(r'\{\{(\w+)\}\}', lambda m: bindings[m.group(1)], a) for a in shortcut.args]
-        base = [a for a in argv if a not in set(extras) and a != args.sql]
-        return main2(base + expanded, init)
+        idx = len(argv) - len(extras) - 1
+        return main2(argv[:idx] + expanded, init)
 
     if args.debug:
         debug_features(args.debug.split(","))

--- a/tests/config/test_merge_init.py
+++ b/tests/config/test_merge_init.py
@@ -50,6 +50,72 @@ def test_simple_shortcut(test_home, capsys, use_old_syntax):
         assert "Shortcuts format has changed" not in err
 
 
+@pytest.mark.parametrize("params,values,sql_template,check", [
+    (["val"], ["hello"], "select '{{val}}' as x", lambda out: "hello" in out),
+    (["a", "b"], ["foo", "bar"], "select '{{a}}' as a, '{{b}}' as b", lambda out: "foo" in out and "bar" in out),
+])
+def test_shortcut_with_params(test_home, capsys, params, values, sql_template, check):
+    """Verify parameterized shortcuts substitute values correctly."""
+    kugl_home().prep().joinpath("init.yaml").write_text(f"""
+        shortcuts:
+          - name: foo
+            args: ["{sql_template}"]
+            params: {params}
+    """)
+    main1(["foo"] + values)
+    out, _ = capsys.readouterr()
+    assert check(out)
+
+
+def test_shortcut_too_few_args(test_home):
+    """Verify error when too few positional args are passed."""
+    kugl_home().prep().joinpath("init.yaml").write_text("""
+        shortcuts:
+          - name: foo
+            args: ["select '{{a}}' as a, '{{b}}' as b"]
+            params: [a, b]
+    """)
+    with pytest.raises(KuglError, match="requires 2 argument\\(s\\): a, b"):
+        main1(["foo", "only-one"])
+
+
+def test_shortcut_too_many_args(test_home):
+    """Verify error when extras are passed to a no-param shortcut."""
+    kugl_home().prep().joinpath("init.yaml").write_text("""
+        shortcuts:
+          - name: foo
+            args: ["select 1"]
+    """)
+    with pytest.raises(KuglError, match="takes no arguments"):
+        main1(["foo", "extra"])
+
+
+def test_shortcut_undeclared_param(test_home):
+    """Verify error at config parse time for undeclared {{token}} in args."""
+    kugl_home().prep().joinpath("init.yaml").write_text("""
+        shortcuts:
+          - name: foo
+            args: ["select '{{undeclared}}'"]
+            params: []
+    """)
+    with pytest.raises(KuglError, match="undeclared parameter"):
+        main1(["foo"])
+
+
+def test_shortcut_with_params_and_flag(test_home, capsys):
+    """Verify flags like -H work alongside parameterized shortcuts."""
+    kugl_home().prep().joinpath("init.yaml").write_text("""
+        shortcuts:
+          - name: foo
+            args: ["select '{{val}}' as x"]
+            params: [val]
+    """)
+    main1(["-H", "foo", "hello"])
+    out, _ = capsys.readouterr()
+    assert "hello" in out
+    assert "x" not in out  # header suppressed
+
+
 @pytest.mark.parametrize("dupe", [True, False])
 def test_shortcuts_in_different_files(test_home, extra_home, dupe: bool, capsys):
     primary_init = kugl_home().joinpath("init.yaml")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,7 +99,7 @@ def test_parse_args(test_home, argv, expected_flag, age, quiet, error):
         with pytest.raises(KuglError, match=error):
             parse_args(argv, ap, settings)
     else:
-        args, actual_flag = parse_args(argv, ap, settings)
+        args, actual_flag, _ = parse_args(argv, ap, settings)
         assert actual_flag == expected_flag
         assert settings.cache_timeout == age
         assert settings.quiet == quiet


### PR DESCRIPTION
Shortcuts can now declare params and accept positional values at invocation, e.g. `kugl pods-in-ns kube-system` where the shortcut uses `{{ns}}` in its args.